### PR TITLE
Introduce new registry approach for RPC groups

### DIFF
--- a/.changeset/happy-geckos-attack.md
+++ b/.changeset/happy-geckos-attack.md
@@ -1,0 +1,7 @@
+---
+'effect-rpc': minor
+---
+
+The new registry-approach allows to define the RPC group once, and use it everywhere, e.g. in Route Handler, on the client and more - this is basically similar to the "legacy" approach, but allows for more purpose/entity/group-bound access. This makes the code more expressive and clear, and way more typesafe.
+
+We've deprecated some functions and features that are not useful and not required to be included. They will be removed in future versions.


### PR DESCRIPTION
Implement a new registry approach for RPC groups to enhance expressiveness and type safety, allowing for clearer and more purpose-driven access throughout the code. Deprecate unnecessary functions and features for future removal.